### PR TITLE
feat: multi-instance phonemizer + en-GB dialect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ phonemize('Hello world!', { returnArray: true })  // IPA array
 - `stripStress` (boolean): Remove stress markers
 - `separator` (string): Phoneme separator (default: ' ')
 - `anyAscii` (boolean): Enable multilingual support via anyAscii transliteration
+- `language` (string): Preferred language tag (BCP 47, e.g. `'en-GB'`). Words written in unambiguously different scripts (CJK, Cyrillic, …) still go through their own processor.
+
+**Language shorthand:** pass a string as the second argument to set `language` directly:
+
+```javascript
+phonemize('doctor', 'en-GB')   // "ˈdɑktə"  (RP)
+phonemize('doctor', 'en-US')   // "ˈdɑktɝ"  (GA, default)
+toIPA('car', 'en-GB')          // "ˈkɑː"
+```
 
 #### `toIPA(text, options?)`
 Convert text to IPA phonemes.
@@ -133,6 +142,57 @@ import { addPronunciation } from 'phonemize'
 addPronunciation('myword', 'ˈmaɪwərd') // Can be IPA or ARPABET
 console.log(phonemize('myword'))  // "ˈmaɪwərd"
 ```
+
+### English Dialects (en-US / en-GB)
+
+The English G2P ships with American English (en-US) as default and a
+rule-based RP (Received Pronunciation) post-processor for en-GB. No
+separate dictionary is shipped — RP is derived from the AmE base via:
+
+- non-rhotic conversion (drop coda /ɹ/, lengthen vowel: `car` → `ˈkɑː`)
+- NURSE split (`bird` → `ˈbɜːd`, `doctor` → `ˈdɑktə`)
+- SQUARE/NEAR/CURE diphthongs (`hair` → `ˈhɛə`, `near` → `ˈnɪə`)
+- word-level overrides for `garage`, `sue`, `super`, `information`,
+  `schedule`, …
+
+```javascript
+import { phonemize, createPhonemizer, EnglishG2P } from 'phonemize'
+
+phonemize('hello world', 'en-GB')  // "həˈɫoʊ ˈwɜːɫd"
+phonemize('garage', 'en-GB')       // "ˈɡæɹɑːʒ"
+
+// Or fix a Phonemizer instance to RP:
+const rp = createPhonemizer({
+  g2ps: [new EnglishG2P({ dialect: 'en-GB' })],
+  language: 'en-GB',
+})
+rp.phonemize('information')        // "ˌɪnfəˈmeɪʃən"
+```
+
+### Multi-instance (`createPhonemizer`)
+
+The default `phonemize()` and `useG2P()` work against a single shared
+G2P registry — convenient, but if you need multiple isolated language
+configurations in the same process, use `createPhonemizer()`:
+
+```javascript
+import { createPhonemizer, EnglishG2P, ChineseG2P } from 'phonemize'
+
+// English-only — won't see Chinese G2P even if registered globally
+const enOnly = createPhonemizer({ g2ps: [new EnglishG2P()] })
+enOnly.phonemize('hello 中文')   // "həˈɫoʊ 中文"  (zh untouched)
+
+// Stack what you want
+const full = createPhonemizer()
+full.useG2P(new EnglishG2P()).useG2P(new ChineseG2P())
+
+// addPronunciation only mutates this instance
+enOnly.addPronunciation('myword', 'ˈmaɪwərd')
+```
+
+`Phonemizer` instances expose the same surface (`phonemize`, `toIPA`,
+`toARPABET`, `toZhuyin`, `addPronunciation`, `createTokenizer`,
+`useG2P`, `unregister`).
 
 ### Advanced Tokenization
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ separate dictionary is shipped — RP is derived from the AmE base via:
   `schedule`, …
 
 ```javascript
-import { phonemize, createPhonemizer, EnglishG2P } from 'phonemize'
+import { phonemize, createPhonemizer } from 'phonemize'
+import EnglishG2P from 'phonemize/en-g2p'
 
 phonemize('hello world', 'en-GB')  // "həˈɫoʊ ˈwɜːɫd"
 phonemize('garage', 'en-GB')       // "ˈɡæɹɑːʒ"
@@ -176,7 +177,9 @@ G2P registry — convenient, but if you need multiple isolated language
 configurations in the same process, use `createPhonemizer()`:
 
 ```javascript
-import { createPhonemizer, EnglishG2P, ChineseG2P } from 'phonemize'
+import { createPhonemizer } from 'phonemize'
+import EnglishG2P from 'phonemize/en-g2p'
+import ChineseG2P from 'phonemize/zh-g2p'
 
 // English-only — won't see Chinese G2P even if registered globally
 const enOnly = createPhonemizer({ g2ps: [new EnglishG2P()] })

--- a/__tests__/en-gb.test.ts
+++ b/__tests__/en-gb.test.ts
@@ -1,0 +1,119 @@
+import { phonemize, toIPA, createPhonemizer } from "../src/all";
+import EnglishG2P from "../src/en-g2p";
+import { transformAmericanToRP } from "../src/en-gb";
+
+describe("en-GB (Received Pronunciation) transformation", () => {
+  describe("non-rhotic transformation", () => {
+    it("strips coda /ɹ/ and lengthens preceding vowel for START class", () => {
+      expect(phonemize("car", "en-GB")).toBe("ˈkɑː");
+      expect(phonemize("far", "en-GB")).toBe("ˈfɑː");
+      expect(phonemize("start", "en-GB")).toBe("ˈstɑːt");
+    });
+
+    it("strips coda /ɹ/ and lengthens preceding vowel for NORTH/FORCE", () => {
+      expect(phonemize("for", "en-GB")).toBe("ˈfɔː");
+      expect(phonemize("more", "en-GB")).toBe("ˈmɔː");
+    });
+
+    it("turns SQUARE class into /ɛə/", () => {
+      expect(phonemize("hair", "en-GB")).toBe("ˈhɛə");
+      expect(phonemize("bear", "en-GB")).toBe("ˈbɛə");
+    });
+
+    it("turns NEAR class into /ɪə/", () => {
+      expect(phonemize("near", "en-GB")).toBe("ˈnɪə");
+    });
+
+    it("turns CURE class into /ʊə/", () => {
+      expect(phonemize("tour", "en-GB")).toBe("ˈtʊə");
+    });
+
+    it("turns FIRE / POWER diphthong+/ɹ/ into the /ə/ ending", () => {
+      expect(phonemize("fire", "en-GB")).toBe("ˈfaɪə");
+      expect(phonemize("hour", "en-GB")).toBe("ˈaʊə");
+    });
+
+    it("preserves onset /ɹ/ between vowels", () => {
+      // ɹ in barrel / very is in onset (followed by a vowel) → must stay
+      expect(phonemize("barrel", "en-GB")).toContain("ɹ");
+      expect(phonemize("very", "en-GB")).toContain("ɹ");
+      expect(phonemize("married", "en-GB")).toContain("ɹ");
+    });
+  });
+
+  describe("NURSE vowel split", () => {
+    it("converts stressed rhotacized schwa /ɝ/ to /ɜː/", () => {
+      expect(phonemize("bird", "en-GB")).toBe("ˈbɜːd");
+      expect(phonemize("word", "en-GB")).toBe("ˈwɜːd");
+      expect(phonemize("nurse", "en-GB")).toBe("ˈnɜːs");
+    });
+
+    it("converts unstressed rhotacized schwa to plain /ə/ (commA-LETTER merger)", () => {
+      expect(phonemize("doctor", "en-GB")).toBe("ˈdɑktə");
+      expect(phonemize("letter", "en-GB")).toBe("ˈɫɛtə");
+      expect(phonemize("teacher", "en-GB")).toContain("tʃə");
+    });
+  });
+
+  describe("word-level RP overrides", () => {
+    it("French /-age/ borrowings end in /ʒ/, not /dʒ/", () => {
+      expect(phonemize("garage", "en-GB")).toContain("ʒ");
+      expect(phonemize("massage", "en-GB")).toContain("ʒ");
+      expect(phonemize("sabotage", "en-GB")).toContain("ʒ");
+    });
+
+    it("retains yod /j/ after /s/ where AmE drops it", () => {
+      expect(phonemize("sue", "en-GB")).toBe("sjuː");
+      expect(phonemize("suit", "en-GB")).toBe("sjuːt");
+      expect(phonemize("super", "en-GB")).toBe("ˈsjuːpə");
+    });
+
+    it("preserves /ɔː/ in -ormation words", () => {
+      // base AmE reduces this to /ɝ/ (rhotacized schwa)
+      expect(phonemize("information", "en-GB")).toBe("ˌɪnfəˈmeɪʃən");
+    });
+
+    it("schedule uses initial /ʃ/ in RP", () => {
+      expect(phonemize("schedule", "en-GB")).toContain("ʃ");
+    });
+  });
+
+  describe("integration", () => {
+    it("does not change AmE output when no language is specified", () => {
+      expect(phonemize("car")).toBe("ˈkɑɹ"); // baseline AmE
+      expect(phonemize("bird")).toBe("ˈbɝd");
+    });
+
+    it("toIPA('text', 'en-GB') yields the RP form", () => {
+      expect(toIPA("doctor", "en-GB")).toBe("ˈdɑktə");
+    });
+
+    it("EnglishG2P({ dialect: 'en-GB' }) instance defaults to RP without explicit tag", () => {
+      const p = createPhonemizer({
+        g2ps: [new EnglishG2P({ dialect: "en-GB" })],
+      });
+      expect(p.phonemize("car")).toBe("ˈkɑː");
+    });
+
+    it("explicit language tag overrides the instance dialect", () => {
+      const p = createPhonemizer({
+        g2ps: [new EnglishG2P({ dialect: "en-GB" })],
+      });
+      expect(p.phonemize("car", "en-US")).toBe("ˈkɑɹ");
+    });
+  });
+
+  describe("transformAmericanToRP unit tests", () => {
+    it("is a pure function on word + AmE IPA", () => {
+      expect(transformAmericanToRP("car", "ˈkɑɹ")).toBe("ˈkɑː");
+      expect(transformAmericanToRP("doctor", "ˈdɑktɝ")).toBe("ˈdɑktə");
+      expect(transformAmericanToRP("bird", "ˈbɝd")).toBe("ˈbɜːd");
+    });
+
+    it("word-override takes precedence over rule-based transform", () => {
+      // sue's rule-based transform would just be "ˈsu" (no ɝ/ɹ); the
+      // override forces yod retention to "sjuː"
+      expect(transformAmericanToRP("sue", "ˈsu")).toBe("sjuː");
+    });
+  });
+});

--- a/__tests__/en-gb.test.ts
+++ b/__tests__/en-gb.test.ts
@@ -1,4 +1,4 @@
-import { phonemize, toIPA, createPhonemizer } from "../src/all";
+import { phonemize, toIPA, toARPABET, createPhonemizer } from "../src/all";
 import EnglishG2P from "../src/en-g2p";
 import { transformAmericanToRP } from "../src/en-gb";
 
@@ -116,6 +116,33 @@ describe("en-GB (Received Pronunciation) transformation", () => {
         g2ps: [new EnglishG2P({ dialect: "en-GB" })],
       });
       expect(p.phonemize("car", "en-US")).toBe("ˈkɑɹ");
+    });
+  });
+
+  describe("ARPABET output for en-GB", () => {
+    it("emits no 'undefined' tokens for words the RP transform touches", () => {
+      // ɜ and ː are RP-only IPA symbols not in the canonical ARPABET
+      // inventory; they should be mapped (ɜ → ER) or stripped (ː) so
+      // ARPABET output is clean.
+      const out = toARPABET("car", "en-GB");
+      expect(out).not.toContain("undefined");
+      expect(out).toContain("AA"); // car → AA1
+    });
+
+    it("NURSE words round-trip to ER in ARPABET", () => {
+      expect(toARPABET("bird", "en-GB")).toContain("ER");
+    });
+  });
+
+  describe("user customDict beats RP lexical override", () => {
+    it("addPronunciation on a shibboleth still wins under en-GB", () => {
+      // 'schedule' is in src-data/en-gb/lexical.json — without this
+      // fix, calling addPronunciation('schedule', ...) would have no
+      // effect for en-GB output.
+      const p = createPhonemizer({ g2ps: [new EnglishG2P()] });
+      p.addPronunciation("schedule", "ɛksɛkjuːʃən"); // arbitrary marker
+      expect(p.phonemize("schedule", "en-GB")).toBe("ɛksɛkjuːʃən");
+      expect(p.phonemize("schedule", "en-US")).toBe("ɛksɛkjuːʃən");
     });
   });
 

--- a/__tests__/en-gb.test.ts
+++ b/__tests__/en-gb.test.ts
@@ -63,9 +63,25 @@ describe("en-GB (Received Pronunciation) transformation", () => {
     });
 
     it("retains yod /j/ after /s/ where AmE drops it", () => {
-      expect(phonemize("sue", "en-GB")).toBe("sjuː");
-      expect(phonemize("suit", "en-GB")).toBe("sjuːt");
+      expect(phonemize("sue", "en-GB")).toBe("ˈsjuː");
+      expect(phonemize("suit", "en-GB")).toBe("ˈsjuːt");
       expect(phonemize("super", "en-GB")).toBe("ˈsjuːpə");
+    });
+
+    it("yod rule does not fire on words like 'sushi' (next IPA is /ʃ/)", () => {
+      expect(phonemize("sushi", "en-GB")).not.toContain("sj");
+    });
+
+    it("French /-age/ rule lengthens the final back vowel and drops /d/", () => {
+      // garage and sabotage have stressed /ɑʒ/ — should lengthen to /ɑːʒ/
+      expect(phonemize("garage", "en-GB")).toContain("ɑːʒ");
+      expect(phonemize("sabotage", "en-GB")).toContain("ɑːʒ");
+      // espionage has /ɑdʒ/ — should drop the /d/ and lengthen
+      expect(phonemize("espionage", "en-GB")).toContain("ɑːʒ");
+      expect(phonemize("espionage", "en-GB")).not.toContain("dʒ");
+      // native English -age stays untouched (no false positive on
+      // marriage / package / image / etc.)
+      expect(phonemize("package", "en-GB")).toContain("dʒ");
     });
 
     it("preserves /ɔː/ in -ormation words", () => {
@@ -110,10 +126,10 @@ describe("en-GB (Received Pronunciation) transformation", () => {
       expect(transformAmericanToRP("bird", "ˈbɝd")).toBe("ˈbɜːd");
     });
 
-    it("word-override takes precedence over rule-based transform", () => {
-      // sue's rule-based transform would just be "ˈsu" (no ɝ/ɹ); the
-      // override forces yod retention to "sjuː"
-      expect(transformAmericanToRP("sue", "ˈsu")).toBe("sjuː");
+    it("lexical exception (en-gb/lexical.json) wins over rule-based transform", () => {
+      // 'schedule' has no rule-derivable form (initial /sk/ → /ʃ/);
+      // the JSON lookup short-circuits the rule pass.
+      expect(transformAmericanToRP("schedule", "ˈskɛdʒuɫ")).toBe("ˈʃɛdjuːl");
     });
   });
 });

--- a/__tests__/multi-instance.test.ts
+++ b/__tests__/multi-instance.test.ts
@@ -1,0 +1,134 @@
+import {
+  phonemize,
+  toIPA,
+  createPhonemizer,
+  Phonemizer,
+  G2PRegistry,
+} from "../src/all";
+import type { G2PProcessor } from "../src/g2p";
+import EnglishG2P from "../src/en-g2p";
+import ChineseG2P from "../src/zh-g2p";
+
+describe("Multi-instance and language preference", () => {
+  describe("phonemize() language shorthand", () => {
+    it("treats a string second arg as preferred language", () => {
+      const us = phonemize("car");
+      const gb = phonemize("car", "en-GB");
+      expect(us).toContain("ɹ"); // rhotic
+      expect(gb).not.toContain("ɹ"); // non-rhotic
+      expect(gb).toContain("ɑː");
+    });
+
+    it("still supports legacy boolean returnArray flag", () => {
+      const result = phonemize("hello", true);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("accepts language via options object", () => {
+      const gb = phonemize("doctor", { language: "en-GB" });
+      expect(gb).toBe("ˈdɑktə");
+    });
+
+    it("does not affect zh tokens — script detection still wins", () => {
+      const result = phonemize("hello 中文", "en-GB");
+      expect(result).toContain("həˈɫoʊ"); // English part still phonemized
+      expect(result).toMatch(/[˥˧]/); // Chinese tones present
+    });
+  });
+
+  describe("toIPA() language shorthand", () => {
+    it("accepts a language string", () => {
+      expect(toIPA("car", "en-GB")).toBe("ˈkɑː");
+      expect(toIPA("car", "en-US")).toBe("ˈkɑɹ");
+    });
+  });
+
+  describe("createPhonemizer", () => {
+    it("creates an isolated registry that does not see global processors", () => {
+      const empty = createPhonemizer();
+      // No processors registered → input echoes back through the tokenizer
+      // unchanged (each token returns null from predictPhonemes, falls
+      // through to the original token).
+      const result = empty.phonemize("hello");
+      expect(result).toBe("hello");
+    });
+
+    it("scopes processors to its own registry", () => {
+      const enOnly = createPhonemizer({ g2ps: [new EnglishG2P()] });
+      const result = enOnly.phonemize("hello 中文");
+      expect(result).toContain("həˈɫoʊ");
+      // No Chinese processor on this instance → 中文 falls through unchanged
+      expect(result).toContain("中文");
+    });
+
+    it("applies a default language across calls", () => {
+      const rp = createPhonemizer({
+        g2ps: [new EnglishG2P()],
+        language: "en-GB",
+      });
+      expect(rp.phonemize("car")).toBe("ˈkɑː");
+      expect(rp.phonemize("doctor")).toBe("ˈdɑktə");
+    });
+
+    it("lets per-call language override the instance default", () => {
+      const rp = createPhonemizer({
+        g2ps: [new EnglishG2P()],
+        language: "en-GB",
+      });
+      expect(rp.phonemize("car", "en-US")).toBe("ˈkɑɹ");
+    });
+
+    it("supports useG2P() chaining for late registration", () => {
+      const p = new Phonemizer();
+      p.useG2P(new EnglishG2P()).useG2P(new ChineseG2P());
+      const result = p.phonemize("hello 中文");
+      expect(result).toContain("həˈɫoʊ");
+      expect(result).toMatch(/[˥˧]/);
+    });
+
+    it("unregister removes a processor from the registry", () => {
+      const p = createPhonemizer({ g2ps: [new EnglishG2P()] });
+      expect(p.phonemize("hello")).toBe("həˈɫoʊ");
+      const removed = p.unregister("en-g2p");
+      expect(removed).toBe(true);
+      expect(p.phonemize("hello")).toBe("hello"); // no processor → passthrough
+    });
+
+    it("addPronunciation only mutates the instance registry", () => {
+      const a = createPhonemizer({ g2ps: [new EnglishG2P()] });
+      const b = createPhonemizer({ g2ps: [new EnglishG2P()] });
+      a.addPronunciation("xyzzy", "ɛksɪzi");
+      expect(a.phonemize("xyzzy")).toBe("ɛksɪzi");
+      // b was created with a fresh EnglishG2P — must not see a's override
+      expect(b.phonemize("xyzzy")).not.toBe("ɛksɪzi");
+    });
+  });
+
+  describe("G2PRegistry language tag matching", () => {
+    it("processor declaring 'en' matches en-GB request (parent fallback)", () => {
+      const reg = new G2PRegistry();
+      reg.register(new EnglishG2P());
+      const proc = reg.findBestProcessor("hello", "en-GB");
+      expect(proc?.id).toBe("en-g2p");
+    });
+
+    it("prefers exact dialect match over parent-tag fallback", () => {
+      class GBOnly implements G2PProcessor {
+        readonly id = "gb-only";
+        readonly name = "British";
+        readonly supportedLanguages = ["en-GB"];
+        predict() {
+          return "rp";
+        }
+        addPronunciation() {}
+      }
+      const reg = new G2PRegistry();
+      reg.register(new EnglishG2P()); // declares en, en-US, en-GB
+      reg.register(new GBOnly()); // only en-GB
+      const proc = reg.findBestProcessor("x", "en-GB");
+      // Both processors declare en-GB. Insertion order should win in a
+      // tie. EnglishG2P was registered first → it's still preferred.
+      expect(proc?.id).toBe("en-g2p");
+    });
+  });
+});

--- a/__tests__/multi-instance.test.ts
+++ b/__tests__/multi-instance.test.ts
@@ -128,6 +128,17 @@ describe("Multi-instance and language preference", () => {
       expect(reg.findBestProcessor("hello", "EN-gb")?.id).toBe("en-g2p");
     });
 
+    it("phonemize honors dialect even with extended BCP 47 subtags", () => {
+      // `en-US-x-foo` (private use) and `en-GB-u-ca-gregory` (extension)
+      // both have the dialect region nested past additional subtags.
+      // Without proper region parsing these would fall back to the
+      // instance default and silently emit AmE for an en-GB request.
+      expect(phonemize("car", "en-GB-u-ca-gregory")).toBe("ˈkɑː");
+      expect(phonemize("car", "en-US-x-private")).toBe("ˈkɑɹ");
+      // Tag with script subtag — region is the third subtag, not second.
+      expect(phonemize("car", "en-Latn-GB")).toBe("ˈkɑː");
+    });
+
     it("mixed-case request still prefers exact dialect over parent", () => {
       // EnglishG2P declares ['en','en-US','en-GB']. A processor
       // declaring only 'en-GB' must outrank the bare-'en' fallback,
@@ -200,6 +211,35 @@ describe("Multi-instance and language preference", () => {
       reg.register(new EnglishG2P());
       const proc = reg.findBestProcessor("hello", "en-GB");
       expect(proc?.id).toBe("en-g2p");
+    });
+
+    it("among parent matches, the longest-prefix tag wins", () => {
+      // For `en-US-x-foo` neither processor exact-matches; both are
+      // parent matches. `en-US` is a longer prefix than `en`, so it
+      // should outrank the bare-`en` processor regardless of registration
+      // order.
+      class EnUS implements G2PProcessor {
+        readonly id = "en-us-only";
+        readonly name = "American";
+        readonly supportedLanguages = ["en-US"];
+        predict() {
+          return "us";
+        }
+        addPronunciation() {}
+      }
+      class EnBare implements G2PProcessor {
+        readonly id = "en-bare";
+        readonly name = "Generic";
+        readonly supportedLanguages = ["en"];
+        predict() {
+          return "bare";
+        }
+        addPronunciation() {}
+      }
+      const reg = new G2PRegistry();
+      reg.register(new EnBare()); // shorter prefix, registered first
+      reg.register(new EnUS()); // longer prefix, registered second
+      expect(reg.findBestProcessor("x", "en-US-x-foo")?.id).toBe("en-us-only");
     });
 
     it("prefers exact dialect match over parent-tag fallback", () => {

--- a/__tests__/multi-instance.test.ts
+++ b/__tests__/multi-instance.test.ts
@@ -34,6 +34,16 @@ describe("Multi-instance and language preference", () => {
       expect(result).toContain("həˈɫoʊ"); // English part still phonemized
       expect(result).toMatch(/[˥˧]/); // Chinese tones present
     });
+
+    it("re-detects per-token script when source has no whitespace boundary", () => {
+      // 'hello中文' tokenizes as 'hello' + '中文'. The languageMap
+      // (built from whitespace-split chunks) only knows the combined
+      // chunk; without per-token re-detection the CJK side would
+      // wrongly inherit the preferred 'en-GB' tag.
+      const result = phonemize("hello中文", "en-GB");
+      expect(result).toContain("həˈɫoʊ");
+      expect(result).toMatch(/[˥˧]/);
+    });
   });
 
   describe("toIPA() language shorthand", () => {
@@ -101,6 +111,55 @@ describe("Multi-instance and language preference", () => {
       expect(a.phonemize("xyzzy")).toBe("ɛksɪzi");
       // b was created with a fresh EnglishG2P — must not see a's override
       expect(b.phonemize("xyzzy")).not.toBe("ɛksɪzi");
+    });
+  });
+
+  describe("BCP 47 case-insensitive matching", () => {
+    it("phonemize accepts en-gb (lowercase) the same as en-GB", () => {
+      expect(phonemize("car", "en-gb")).toBe("ˈkɑː");
+      expect(phonemize("car", "EN-GB")).toBe("ˈkɑː");
+      expect(phonemize("car", "en-Gb")).toBe("ˈkɑː");
+    });
+
+    it("registry lookup is case-insensitive on the request tag", () => {
+      const reg = new G2PRegistry();
+      reg.register(new EnglishG2P());
+      expect(reg.findBestProcessor("hello", "en-GB")?.id).toBe("en-g2p");
+      expect(reg.findBestProcessor("hello", "EN-gb")?.id).toBe("en-g2p");
+    });
+  });
+
+  describe("registry register / unregister hygiene", () => {
+    it("re-registering an id swaps the implementation in place", () => {
+      class FakeEn implements G2PProcessor {
+        readonly id = "en-g2p";
+        readonly name: string;
+        readonly supportedLanguages = ["en"];
+        constructor(public marker: string) {
+          this.name = "Fake " + marker;
+        }
+        predict() {
+          return this.marker;
+        }
+        addPronunciation() {}
+      }
+      const reg = new G2PRegistry();
+      reg.register(new FakeEn("v1"));
+      reg.register(new FakeEn("v2"));
+      // After swap, only one entry per id and dispatch hits the new one.
+      expect(reg.getAllProcessors()).toHaveLength(1);
+      expect(reg.findBestProcessor("anything", "en")?.predict("anything")).toBe(
+        "v2",
+      );
+    });
+
+    it("unregister removes every reference, not just one", () => {
+      const reg = new G2PRegistry();
+      reg.register(new EnglishG2P());
+      reg.register(new EnglishG2P()); // same id, replaces in place
+      expect(reg.unregister("en-g2p")).toBe(true);
+      expect(reg.getAllProcessors()).toHaveLength(0);
+      expect(reg.findBestProcessor("hello", "en")).toBeNull();
     });
   });
 

--- a/__tests__/multi-instance.test.ts
+++ b/__tests__/multi-instance.test.ts
@@ -127,6 +127,37 @@ describe("Multi-instance and language preference", () => {
       expect(reg.findBestProcessor("hello", "en-GB")?.id).toBe("en-g2p");
       expect(reg.findBestProcessor("hello", "EN-gb")?.id).toBe("en-g2p");
     });
+
+    it("mixed-case request still prefers exact dialect over parent", () => {
+      // EnglishG2P declares ['en','en-US','en-GB']. A processor
+      // declaring only 'en-GB' must outrank the bare-'en' fallback,
+      // even when the request tag is mixed case.
+      class GBOnly implements G2PProcessor {
+        readonly id = "gb-only";
+        readonly name = "British";
+        readonly supportedLanguages = ["en-GB"];
+        predict() {
+          return "rp-only";
+        }
+        addPronunciation() {}
+      }
+      class EnOnly implements G2PProcessor {
+        readonly id = "en-only";
+        readonly name = "English";
+        readonly supportedLanguages = ["en"];
+        predict() {
+          return "en-only";
+        }
+        addPronunciation() {}
+      }
+      const reg = new G2PRegistry();
+      reg.register(new EnOnly()); // parent tag, registered first
+      reg.register(new GBOnly()); // exact dialect, registered second
+      // Without case-insensitive exact match, 'EN-GB' would skip the
+      // exact bucket and the parent EnOnly would win.
+      expect(reg.findBestProcessor("x", "EN-GB")?.id).toBe("gb-only");
+      expect(reg.findBestProcessor("x", "en-gb")?.id).toBe("gb-only");
+    });
   });
 
   describe("registry register / unregister hygiene", () => {

--- a/src-data/en-gb/lexical.json
+++ b/src-data/en-gb/lexical.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "ˈʃɛdjuːl",
+  "tomato": "təˈmɑːtəʊ",
+  "vase": "vɑːz",
+  "herb": "hɜːb",
+  "zebra": "ˈzɛbɹə",
+  "lieutenant": "lɛfˈtɛnənt"
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -130,11 +130,21 @@ export const CHINESE_TONE_TO_ARROW: Record<string, string> = {
 };
 
 /**
- * Reverse mappings for conversion utilities
+ * Reverse mappings for conversion utilities. Auto-generated from the
+ * ARPABET→IPA table, plus a few extras for IPA symbols that the
+ * en-GB / RP transform produces but that don't appear in the canonical
+ * ARPABET inventory (which is American-English flavoured).
  */
-export const IPA_TO_ARPABET = Object.fromEntries(
-  Object.entries(ARPABET_TO_IPA).map(([key, value]) => [value, key])
-) as Record<string, string>;
+export const IPA_TO_ARPABET: Record<string, string> = {
+  ...Object.fromEntries(
+    Object.entries(ARPABET_TO_IPA).map(([key, value]) => [value, key]),
+  ),
+  // RP NURSE — same vowel as ɝ when stripped of rhoticity.
+  "ɜ": "ER",
+  // RP LOT — rounded back vowel; map to AA so consumers get a back
+  // vowel rather than nothing.
+  "ɒ": "AA",
+};
 
 export const IPA_TO_STRESS = Object.fromEntries(
   Object.entries(IPA_STRESS_MAP).map(([key, value]) => [value, key])

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,182 +1,282 @@
 /**
  * Phonemize Library - Main API
- * 
+ *
  * A comprehensive text-to-phoneme conversion library supporting:
  * - IPA (International Phonetic Alphabet) output
  * - ARPABET phonetic notation
  * - Number and abbreviation expansion
+ *
+ * The default exports (`phonemize`, `useG2P`, `addPronunciation`, ...) read
+ * and write a single global G2P registry, which is what `phonemize/index`
+ * and `phonemize/all` populate. To run an isolated set of processors —
+ * e.g. force English-only output, or stack two unrelated language
+ * configurations in the same process — use `createPhonemizer()` instead.
  */
 
 import { Tokenizer, TokenizerOptions, PhonemeToken } from "./tokenizer";
-import { getG2PProcessor, useG2P } from "./g2p";
+import {
+  G2PRegistry,
+  g2pRegistry as defaultRegistry,
+  useG2P,
+} from "./g2p";
+import type { G2PProcessor } from "./g2p";
 
 // Re-export core types and classes for public API
 export type { TokenizerOptions, PhonemeToken };
-export { Tokenizer, useG2P };
+export { Tokenizer, useG2P, G2PRegistry };
 
 export type { G2PProcessor } from "./g2p";
 
+/** Optional second-argument shorthand: bare string is treated as `language`. */
+type PhonemizeArg =
+  | true
+  | string
+  | (TokenizerOptions & { returnArray?: boolean });
+
+function normalizeArg(
+  arg: PhonemizeArg | undefined,
+): TokenizerOptions & { returnArray?: boolean } {
+  if (arg === undefined) return {};
+  if (arg === true) return { returnArray: true };
+  if (typeof arg === "string") return { language: arg };
+  return arg;
+}
+
 /**
  * Convert text to phonetic representation
- * 
- * @param text - Input text to convert
- * @param options - Configuration options with returnArray flag
- * @returns Array of phoneme tokens with metadata
  */
 export function phonemize(
   text: string,
   options: TokenizerOptions & { returnArray: true },
 ): PhonemeToken[];
-
-/**
- * Convert text to phonetic representation
- * 
- * @param text - Input text to convert
- * @param options - Configuration options
- * @returns Space-separated phoneme string
- */
 export function phonemize(text: string, options?: TokenizerOptions): string;
-
-/**
- * Convert text to phonetic representation (legacy array format)
- * 
- * @param text - Input text to convert
- * @param returnArray - If true, return array format
- * @returns Array of phoneme tokens
- */
 export function phonemize(text: string, returnArray: true): PhonemeToken[];
-
 /**
- * Main phonemize function implementation
+ * Shorthand: pass a language tag (e.g. `"en-GB"`) as the second argument
+ * to bias dispatch toward processors matching that tag.
  */
-export function phonemize(
-  text: string,
-  options: true | (TokenizerOptions & { returnArray?: boolean }) = {},
-): string | PhonemeToken[] {
-  // Handle legacy boolean parameter
-  if (options === true) {
-    options = { returnArray: true };
-  }
-
+export function phonemize(text: string, language: string): string;
+export function phonemize(text: string, arg: PhonemizeArg = {}): string | PhonemeToken[] {
+  const options = normalizeArg(arg);
   const tokenizer = new Tokenizer(options);
-  
-  if (options.returnArray) {
-    return tokenizer.tokenizeToTokens(text);
-  }
-  
-  return tokenizer.tokenizeToString(text);
+  return options.returnArray
+    ? tokenizer.tokenizeToTokens(text)
+    : tokenizer.tokenizeToString(text);
 }
 
 /**
  * Convert text to International Phonetic Alphabet (IPA) notation
- * 
- * @param text - Input text to convert
- * @param options - Configuration options (format will be overridden to 'ipa')
- * @returns IPA phonetic string
- * 
+ *
  * @example
  * ```typescript
  * toIPA("hello world") // "həloʊ wɝld"
  * toIPA("中文", { anyAscii: false }) // "ʈʂʊŋ˥˥ wən˧˥"
+ * toIPA("hello", "en-GB") // RP-flavored output
  * ```
  */
 export function toIPA(
   text: string,
-  options?: Omit<TokenizerOptions, "format">,
+  options?: Omit<TokenizerOptions, "format"> | string,
 ): string {
-  const ipaOptions: TokenizerOptions = { ...options, format: "ipa" };
-  const tokenizer = new Tokenizer(ipaOptions);
-  return tokenizer.tokenizeToString(text);
+  const opts =
+    typeof options === "string" ? { language: options } : options ?? {};
+  const ipaOptions: TokenizerOptions = { ...opts, format: "ipa" };
+  return new Tokenizer(ipaOptions).tokenizeToString(text);
 }
 
 /**
  * Convert text to ARPABET phonetic notation
- * 
- * @param text - Input text to convert
- * @param options - Configuration options (format will be overridden to 'arpabet')
- * @returns ARPABET phonetic string
- * 
- * @example
- * ```typescript
- * toARPABET("hello world") // "HH AH L OW W ER L D"
- * toARPABET("testing", { stripStress: true }) // "T EH S T IH NG"
- * ```
  */
 export function toARPABET(
   text: string,
-  options?: Omit<TokenizerOptions, "format">,
+  options?: Omit<TokenizerOptions, "format"> | string,
 ): string {
-  const arpabetOptions: TokenizerOptions = { ...options, format: "arpabet" };
-  const tokenizer = new Tokenizer(arpabetOptions);
-  return tokenizer.tokenizeToString(text);
+  const opts =
+    typeof options === "string" ? { language: options } : options ?? {};
+  const arpabetOptions: TokenizerOptions = { ...opts, format: "arpabet" };
+  return new Tokenizer(arpabetOptions).tokenizeToString(text);
 }
 
 /**
- * Convert text to Zhuyin (Bopomofo) notation
- * Chinese characters are converted to Zhuyin with tone numbers,
- * non-Chinese characters are converted to IPA as fallback.
- * 
- * @param text - Input text to convert
- * @param options - Configuration options (format will be overridden to 'zhuyin')
- * @returns Zhuyin phonetic string with tone numbers
- * 
- * @example
- * ```typescript
- * toZhuyin("中文") // "ㄓㄨㄥ1 ㄨㄣ2"
- * toZhuyin("中文 hello") // "ㄓㄨㄥ1 ㄨㄣ2 həˈloʊ"
- * toZhuyin("測試", { stripStress: true }) // "ㄘㄜ4 ㄕ4"
- * ```
+ * Convert text to Zhuyin (Bopomofo) notation. Chinese characters are
+ * converted to Zhuyin with tone numbers; non-Chinese characters fall
+ * back to IPA.
  */
 export function toZhuyin(
   text: string,
-  options?: Omit<TokenizerOptions, "format">,
+  options?: Omit<TokenizerOptions, "format"> | string,
 ): string {
-  const zhuyinOptions: TokenizerOptions = { ...options, format: "zhuyin" };
-  const tokenizer = new Tokenizer(zhuyinOptions);
-  return tokenizer.tokenizeToString(text);
+  const opts =
+    typeof options === "string" ? { language: options } : options ?? {};
+  const zhuyinOptions: TokenizerOptions = { ...opts, format: "zhuyin" };
+  return new Tokenizer(zhuyinOptions).tokenizeToString(text);
 }
 
 /**
- * Add custom pronunciation to the internal dictionary
- * 
- * @param word - Word to add pronunciation for
- * @param pronunciation - IPA pronunciation string
- * 
- * @example
- * ```typescript
- * addPronunciation("github", "ɡɪthʌb");
- * toIPA("github") // "ɡɪthʌb"
- * ```
+ * Add a custom pronunciation to the default global registry's matching
+ * processor. For multi-instance setups, use `Phonemizer#addPronunciation`.
  */
-export function addPronunciation(word: string, pronunciation: string, language?: string): void {
+export function addPronunciation(
+  word: string,
+  pronunciation: string,
+  language?: string,
+): void {
   if (!word?.trim() || !pronunciation?.trim()) {
     throw new Error("Both word and pronunciation must be non-empty strings");
   }
-  
-  // Use the registered English G2P processor to add pronunciation
-  const processor = getG2PProcessor(word, language);
+  const processor = defaultRegistry.findBestProcessor(word, language);
   processor?.addPronunciation(word.toLowerCase(), pronunciation);
 }
 
 /**
- * Create a custom tokenizer instance with specific configuration
- * 
- * @param options - Tokenizer configuration options
- * @returns Configured Tokenizer instance
- * 
- * @example
- * ```typescript
- * const tokenizer = createTokenizer({
- *   format: "ipa",
- *   stripStress: true,
- *   separator: "-"
- * });
- * 
- * const result = tokenizer.tokenizeToString("hello");
- * ```
+ * Create a custom tokenizer instance with specific configuration. Useful
+ * when you want to reuse the same options across many calls.
  */
 export function createTokenizer(options: TokenizerOptions = {}): Tokenizer {
   return new Tokenizer(options);
+}
+
+// === Multi-instance API =====================================================
+
+/**
+ * Options for `createPhonemizer()`.
+ */
+export interface PhonemizerOptions {
+  /**
+   * Initial set of G2P processors. Equivalent to calling `useG2P()` for
+   * each on a freshly created instance. The first registered processor
+   * is the default fallback when no language is provided.
+   */
+  g2ps?: G2PProcessor[];
+  /**
+   * Default language tag applied to every call (overridable per-call).
+   */
+  language?: string;
+}
+
+/**
+ * An isolated phonemizer with its own G2P registry. Use this when you
+ * want to register a different set of languages per call site without
+ * mutating the global registry — for example, a server that handles
+ * one user request with English-only output and another with the full
+ * multilingual stack.
+ *
+ * @example
+ * ```ts
+ * import { createPhonemizer, EnglishG2P } from "phonemize";
+ *
+ * const enOnly = createPhonemizer({ g2ps: [new EnglishG2P()] });
+ * enOnly.phonemize("hello 中文"); // "həˈɫoʊ 中文"  (zh untouched)
+ *
+ * const rp = createPhonemizer({
+ *   g2ps: [new EnglishG2P({ dialect: "en-GB" })],
+ *   language: "en-GB",
+ * });
+ * rp.phonemize("doctor"); // RP transformation applied
+ * ```
+ */
+export class Phonemizer {
+  readonly registry: G2PRegistry;
+  private readonly defaultLanguage?: string;
+
+  constructor(options: PhonemizerOptions = {}) {
+    this.registry = new G2PRegistry();
+    if (options.g2ps) {
+      for (const p of options.g2ps) this.registry.register(p);
+    }
+    this.defaultLanguage = options.language;
+  }
+
+  useG2P(processor: G2PProcessor): this {
+    this.registry.register(processor);
+    return this;
+  }
+
+  unregister(id: string): boolean {
+    return this.registry.unregister(id);
+  }
+
+  private _resolve(
+    arg?: PhonemizeArg,
+  ): TokenizerOptions & { returnArray?: boolean } {
+    const opts = normalizeArg(arg);
+    return {
+      ...opts,
+      registry: this.registry,
+      language: opts.language ?? this.defaultLanguage,
+    };
+  }
+
+  phonemize(
+    text: string,
+    options: TokenizerOptions & { returnArray: true },
+  ): PhonemeToken[];
+  phonemize(text: string, options?: TokenizerOptions): string;
+  phonemize(text: string, returnArray: true): PhonemeToken[];
+  phonemize(text: string, language: string): string;
+  phonemize(text: string, arg: PhonemizeArg = {}): string | PhonemeToken[] {
+    const options = this._resolve(arg);
+    const tokenizer = new Tokenizer(options);
+    return options.returnArray
+      ? tokenizer.tokenizeToTokens(text)
+      : tokenizer.tokenizeToString(text);
+  }
+
+  toIPA(text: string, options?: Omit<TokenizerOptions, "format"> | string): string {
+    const opts = typeof options === "string" ? { language: options } : options ?? {};
+    return new Tokenizer({
+      ...opts,
+      format: "ipa",
+      registry: this.registry,
+      language: opts.language ?? this.defaultLanguage,
+    }).tokenizeToString(text);
+  }
+
+  toARPABET(text: string, options?: Omit<TokenizerOptions, "format"> | string): string {
+    const opts = typeof options === "string" ? { language: options } : options ?? {};
+    return new Tokenizer({
+      ...opts,
+      format: "arpabet",
+      registry: this.registry,
+      language: opts.language ?? this.defaultLanguage,
+    }).tokenizeToString(text);
+  }
+
+  toZhuyin(text: string, options?: Omit<TokenizerOptions, "format"> | string): string {
+    const opts = typeof options === "string" ? { language: options } : options ?? {};
+    return new Tokenizer({
+      ...opts,
+      format: "zhuyin",
+      registry: this.registry,
+      language: opts.language ?? this.defaultLanguage,
+    }).tokenizeToString(text);
+  }
+
+  addPronunciation(word: string, pronunciation: string, language?: string): void {
+    if (!word?.trim() || !pronunciation?.trim()) {
+      throw new Error("Both word and pronunciation must be non-empty strings");
+    }
+    const processor = this.registry.findBestProcessor(
+      word,
+      language ?? this.defaultLanguage,
+    );
+    processor?.addPronunciation(word.toLowerCase(), pronunciation);
+  }
+
+  createTokenizer(options: TokenizerOptions = {}): Tokenizer {
+    return new Tokenizer({
+      ...options,
+      registry: this.registry,
+      language: options.language ?? this.defaultLanguage,
+    });
+  }
+}
+
+/**
+ * Factory shorthand for `new Phonemizer(options)`.
+ */
+export function createPhonemizer(options: PhonemizerOptions = {}): Phonemizer {
+  return new Phonemizer(options);
 }
 
 /**
@@ -194,9 +294,12 @@ const phonemizer = {
   addPronunciation,
   createTokenizer,
   useG2P,
+  createPhonemizer,
 
   // === Classes ===
   Tokenizer,
+  Phonemizer,
+  G2PRegistry,
 } as const;
 
 export default phonemizer;

--- a/src/en-g2p.ts
+++ b/src/en-g2p.ts
@@ -278,12 +278,16 @@ export class G2PModel implements G2PProcessor {
       return this.customDict[lowerWord];
     }
 
-    // Resolve effective dialect: explicit dialect tag > instance default.
-    // Bare "en" (no region) defers to whichever dialect this instance
-    // was constructed with.
+    // Extract the region subtag from a BCP 47 tag. Skips an optional
+    // 4-letter script (e.g. `en-Latn-US`) and stops at any extension
+    // singleton (`-u-…`, `-x-…`). Matches alpha-2 (`gb`) or digit-3
+    // (`419`) regions. So `en-US-x-foo`, `en-Latn-GB`, and `EN-GB-u-ca-gregory`
+    // all surface their region correctly.
+    const regionMatch = tag?.match(/^en(?:-[a-z]{4})?-([a-z]{2}|\d{3})(?:$|-)/);
+    const region = regionMatch?.[1];
     const dialect: EnglishDialect =
-      tag === "en-gb" ? "en-GB" :
-      tag === "en-us" ? "en-US" :
+      region === "gb" ? "en-GB" :
+      region === "us" ? "en-US" :
       this.dialect;
 
     const base = this.predictInternal(word, pos, this.disableDict);

--- a/src/en-g2p.ts
+++ b/src/en-g2p.ts
@@ -2,6 +2,9 @@ import * as dictionary from "../data/en/dict.json";
 import * as homographs from "../data/en/homographs.json";
 import { arpabetToIpa, resolveJson } from "./utils";
 import { G2PProcessor } from "./g2p";
+import { transformAmericanToRP } from "./en-gb";
+
+export type EnglishDialect = "en-US" | "en-GB";
 
 // --- Type Definitions ---
 
@@ -227,28 +230,53 @@ const PHONEME_RULES: Array<[RegExp, string]> = [
 
 export class G2PModel implements G2PProcessor {
   private dictionary: EnDict;
+  /**
+   * Per-instance custom pronunciations. We keep these separate from
+   * `this.dictionary` (which references the shared module-level JSON
+   * object) so that `addPronunciation()` on one instance doesn't leak
+   * to other instances created in the same process.
+   */
+  private customDict: EnDict = {};
   private homographs: HomographDict;
   private disableDict: boolean;
+  private dialect: EnglishDialect;
 
   // G2PProcessor interface implementation
   readonly id = "en-g2p";
   readonly name = "English G2P Processor";
-  readonly supportedLanguages = ["en"];
+  /**
+   * Accepts the bare `en` tag plus both major dialects. The same
+   * instance can serve both — see `predict()` for per-call dispatch.
+   */
+  readonly supportedLanguages = ["en", "en-US", "en-GB"];
 
-  constructor(options: { disableDict?: boolean } = {}) {
+  constructor(options: { disableDict?: boolean; dialect?: EnglishDialect } = {}) {
     this.disableDict = options.disableDict || false;
+    this.dialect = options.dialect ?? "en-US";
     this.dictionary = resolveJson<EnDict>(dictionary);
     this.homographs = resolveJson<HomographDict>(homographs);
   }
 
   predict(word: string, language?: string, pos?: string): string | null {
-    // If language is specified and not English, return null
-    if (language && language !== 'en') {
-      return null;
+    // Reject non-English requests. We accept `en`, `en-US`, `en-GB`,
+    // and any unspecified language (registry fallback uses us).
+    if (language) {
+      const primary = language.indexOf("-") === -1 ? language : language.slice(0, language.indexOf("-"));
+      if (primary !== "en") return null;
     }
-    
-    // Use the existing predict method
-    return this.predictInternal(word, pos, this.disableDict);
+
+    // Resolve effective dialect: explicit dialect tag > instance default.
+    // Bare "en" (no region) defers to whichever dialect this instance
+    // was constructed with.
+    const dialect: EnglishDialect =
+      language === "en-GB" ? "en-GB" :
+      language === "en-US" ? "en-US" :
+      this.dialect;
+
+    const base = this.predictInternal(word, pos, this.disableDict);
+    if (!base) return base;
+
+    return dialect === "en-GB" ? transformAmericanToRP(word, base) : base;
   }
 
   private predictInternal(
@@ -364,6 +392,9 @@ export class G2PModel implements G2PProcessor {
       if (homograph) {
         return homograph.pronunciation;
       }
+    }
+    if (this.customDict[word]) {
+      return this.customDict[word];
     }
     if (this.dictionary[word]) {
       return this.dictionary[word];
@@ -848,7 +879,7 @@ export class G2PModel implements G2PProcessor {
     if (!pronunciation.match(/^[A-Z0-9]+$/)) {
       pronunciation = arpabetToIpa(pronunciation);
     }
-    this.dictionary[word.toLowerCase()] = pronunciation;
+    this.customDict[word.toLowerCase()] = pronunciation;
   }
 }
 

--- a/src/en-g2p.ts
+++ b/src/en-g2p.ts
@@ -258,19 +258,32 @@ export class G2PModel implements G2PProcessor {
   }
 
   predict(word: string, language?: string, pos?: string): string | null {
-    // Reject non-English requests. We accept `en`, `en-US`, `en-GB`,
+    // BCP 47 tags are case-insensitive — `en-gb`, `EN-GB`, `en-GB`
+    // all mean the same dialect.
+    const tag = language?.toLowerCase();
+
+    // Reject non-English requests. We accept `en`, `en-us`, `en-gb`,
     // and any unspecified language (registry fallback uses us).
-    if (language) {
-      const primary = language.indexOf("-") === -1 ? language : language.slice(0, language.indexOf("-"));
+    if (tag) {
+      const primary = tag.indexOf("-") === -1 ? tag : tag.slice(0, tag.indexOf("-"));
       if (primary !== "en") return null;
+    }
+
+    // User-supplied custom pronunciations short-circuit dialect
+    // routing: if the caller explicitly set a pronunciation via
+    // addPronunciation(), they presumably picked one that's right
+    // for their use case. Don't run the RP transform over it.
+    const lowerWord = word.toLowerCase();
+    if (this.customDict[lowerWord]) {
+      return this.customDict[lowerWord];
     }
 
     // Resolve effective dialect: explicit dialect tag > instance default.
     // Bare "en" (no region) defers to whichever dialect this instance
     // was constructed with.
     const dialect: EnglishDialect =
-      language === "en-GB" ? "en-GB" :
-      language === "en-US" ? "en-US" :
+      tag === "en-gb" ? "en-GB" :
+      tag === "en-us" ? "en-US" :
       this.dialect;
 
     const base = this.predictInternal(word, pos, this.disableDict);

--- a/src/en-gb.ts
+++ b/src/en-gb.ts
@@ -1,0 +1,99 @@
+/**
+ * RP (Received Pronunciation) post-processing for English G2P output.
+ *
+ * The base English G2P returns General American IPA. This module turns
+ * that output into a reasonable RP/Southern Standard British rendering
+ * via rule-based transformation — no separate dictionary file is loaded
+ * (which would roughly double the package size).
+ *
+ * Coverage is intentionally conservative. We handle the high-impact
+ * RP↔GA differences (non-rhoticity, NURSE, rhotic-vowel diphthongs,
+ * yod retention, French `-age`) and leave subtler choices (LOT
+ * rounding to /ɒ/, FOOT-STRUT split, smoothing) to consumers who need
+ * them.
+ */
+
+/**
+ * Words whose RP form is irregular enough that a rule-based pass alone
+ * gets it wrong. Keys are lowercase. Entries should be the full RP IPA
+ * (post-transform output is replaced wholesale, not patched).
+ */
+const RP_WORD_OVERRIDES: Record<string, string> = {
+  // French -age borrowings keep /ʒ/ in RP (vs AmE /dʒ/)
+  garage: "ˈɡæɹɑːʒ",
+  massage: "ˈmæsɑːʒ",
+  barrage: "ˈbæɹɑːʒ",
+  camouflage: "ˈkæməflɑːʒ",
+  sabotage: "ˈsæbətɑːʒ",
+  espionage: "ˈɛspiənɑːʒ",
+  reportage: "ɹɪˈpɔːtɑːʒ",
+
+  // Yod retention after /s/ where AmE drops it
+  sue: "sjuː",
+  suit: "sjuːt",
+  super: "ˈsjuːpə",
+  superb: "sjuːˈpɜːb",
+
+  // -ormation series: AmE reduces the /ɔː/ to schwa, RP preserves it
+  information: "ˌɪnfəˈmeɪʃən",
+  transformation: "ˌtɹænsfəˈmeɪʃən",
+  reformation: "ˌɹɛfəˈmeɪʃən",
+  confirmation: "ˌkɒnfəˈmeɪʃən",
+
+  // Shibboleth pronunciations
+  schedule: "ˈʃɛdjuːl",
+  tomato: "təˈmɑːtəʊ",
+  vase: "vɑːz",
+  herb: "hɜːb",
+  zebra: "ˈzɛbɹə",
+  lieutenant: "lɛfˈtɛnənt",
+};
+
+/**
+ * Pure rule-based AmE → RP transformation. Order matters: rhotic-vowel
+ * pairs run first so the leftover /ɹ/-drop pass only sees "stranded"
+ * coda /ɹ/ in unusual spellings.
+ */
+function applyRPRules(ipa: string): string {
+  let out = ipa;
+
+  // 1. Split rhotacized /ɝ/ by stress. AmE collapses NURSE (stressed)
+  //    and rhotacized schwa (unstressed) into the same symbol; RP
+  //    splits them into /ɜː/ and /ə/ respectively. A /ɝ/ counts as
+  //    stressed when only consonants sit between it and the most
+  //    recent stress mark — i.e. it's the first vowel of that syllable.
+  out = out.replace(/([ˈˌ][^ˈˌaeiouæɑɒəɛɪʌʊɔ]*)ɝ/g, "$1ɜː");
+  out = out.replace(/ɝ/g, "ə"); // any remaining /ɝ/ is unstressed
+
+  // 2. SQUARE/NEAR/CURE diphthongs replace V+ɹ in coda. The lookahead
+  //    ensures we don't touch onset /ɹ/ (e.g. "barrel" /bæɹəl/ stays).
+  out = out
+    .replace(/aɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aɪə") // FIRE — match before ɑɹ
+    .replace(/aʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aʊə") // POWER
+    .replace(/ɑɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɑː") // START
+    .replace(/ɔɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɔː") // NORTH/FORCE
+    .replace(/ɛɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɛə") // SQUARE
+    .replace(/ɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɪə") // NEAR
+    .replace(/ʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ʊə"); // CURE
+
+  // 3. Drop any remaining /ɹ/ in coda position (before a consonant or
+  //    word boundary). Onset /ɹ/ — followed by a vowel — is preserved.
+  out = out.replace(/ɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "");
+
+  // 4. Tidy stray /əː/ artifacts → /ɜː/.
+  out = out.replace(/əː/g, "ɜː");
+
+  return out;
+}
+
+/**
+ * Convert American-English IPA to RP IPA for the given word. Handles
+ * word-level overrides first, then rule-based transformation.
+ */
+export function transformAmericanToRP(word: string, ipaUS: string): string {
+  const lower = word.toLowerCase();
+  const override = RP_WORD_OVERRIDES[lower];
+  if (override) return override;
+
+  return applyRPRules(ipaUS);
+}

--- a/src/en-gb.ts
+++ b/src/en-gb.ts
@@ -2,59 +2,41 @@
  * RP (Received Pronunciation) post-processing for English G2P output.
  *
  * The base English G2P returns General American IPA. This module turns
- * that output into a reasonable RP/Southern Standard British rendering
+ * that output into a reasonable RP / Southern Standard British rendering
  * via rule-based transformation — no separate dictionary file is loaded
  * (which would roughly double the package size).
  *
- * Coverage is intentionally conservative. We handle the high-impact
- * RP↔GA differences (non-rhoticity, NURSE, rhotic-vowel diphthongs,
- * yod retention, French `-age`) and leave subtler choices (LOT
- * rounding to /ɒ/, FOOT-STRUT split, smoothing) to consumers who need
- * them.
+ * Coverage is intentionally conservative:
+ *   - non-rhoticity (drop coda /ɹ/, lengthen the preceding vowel)
+ *   - NURSE split: stressed /ɝ/ → /ɜː/, unstressed → /ə/
+ *   - SQUARE / NEAR / CURE diphthongs from /Vɹ/ pairs
+ *   - FIRE / POWER from diphthong + /ɹ/
+ *   - French -age borrowings: lengthen final stressed vowel + drop /d/
+ *   - yod retention after word-initial /s/ (sue, suit, super, …)
+ *
+ * Words whose RP form genuinely can't be derived by rule (schedule,
+ * tomato, herb, …) live in `src-data/en-gb/lexical.json`, not in this
+ * source file.
  */
+
+import { resolveJson } from "./utils";
+import * as lexicalData from "../src-data/en-gb/lexical.json";
 
 /**
- * Words whose RP form is irregular enough that a rule-based pass alone
- * gets it wrong. Keys are lowercase. Entries should be the full RP IPA
- * (post-transform output is replaced wholesale, not patched).
+ * Lexical exceptions — true shibboleths whose RP pronunciation diverges
+ * from AmE in ways no general phonological rule predicts. Edit the JSON
+ * to add or correct entries; keep this file rule-only.
  */
-const RP_WORD_OVERRIDES: Record<string, string> = {
-  // French -age borrowings keep /ʒ/ in RP (vs AmE /dʒ/)
-  garage: "ˈɡæɹɑːʒ",
-  massage: "ˈmæsɑːʒ",
-  barrage: "ˈbæɹɑːʒ",
-  camouflage: "ˈkæməflɑːʒ",
-  sabotage: "ˈsæbətɑːʒ",
-  espionage: "ˈɛspiənɑːʒ",
-  reportage: "ɹɪˈpɔːtɑːʒ",
-
-  // Yod retention after /s/ where AmE drops it
-  sue: "sjuː",
-  suit: "sjuːt",
-  super: "ˈsjuːpə",
-  superb: "sjuːˈpɜːb",
-
-  // -ormation series: AmE reduces the /ɔː/ to schwa, RP preserves it
-  information: "ˌɪnfəˈmeɪʃən",
-  transformation: "ˌtɹænsfəˈmeɪʃən",
-  reformation: "ˌɹɛfəˈmeɪʃən",
-  confirmation: "ˌkɒnfəˈmeɪʃən",
-
-  // Shibboleth pronunciations
-  schedule: "ˈʃɛdjuːl",
-  tomato: "təˈmɑːtəʊ",
-  vase: "vɑːz",
-  herb: "hɜːb",
-  zebra: "ˈzɛbɹə",
-  lieutenant: "lɛfˈtɛnənt",
-};
+const RP_LEXICAL: Record<string, string> = resolveJson<Record<string, string>>(
+  lexicalData,
+);
 
 /**
  * Pure rule-based AmE → RP transformation. Order matters: rhotic-vowel
  * pairs run first so the leftover /ɹ/-drop pass only sees "stranded"
  * coda /ɹ/ in unusual spellings.
  */
-function applyRPRules(ipa: string): string {
+function applyRPRules(word: string, ipa: string): string {
   let out = ipa;
 
   // 1. Split rhotacized /ɝ/ by stress. AmE collapses NURSE (stressed)
@@ -67,14 +49,15 @@ function applyRPRules(ipa: string): string {
 
   // 2. SQUARE/NEAR/CURE diphthongs replace V+ɹ in coda. The lookahead
   //    ensures we don't touch onset /ɹ/ (e.g. "barrel" /bæɹəl/ stays).
+  //    FIRE / POWER (diphthong + ɹ) must run before bare ɑɹ / aʊɹ.
   out = out
-    .replace(/aɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aɪə") // FIRE — match before ɑɹ
-    .replace(/aʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aʊə") // POWER
-    .replace(/ɑɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɑː") // START
-    .replace(/ɔɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɔː") // NORTH/FORCE
-    .replace(/ɛɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɛə") // SQUARE
-    .replace(/ɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɪə") // NEAR
-    .replace(/ʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ʊə"); // CURE
+    .replace(/aɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aɪə")
+    .replace(/aʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "aʊə")
+    .replace(/ɑɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɑː")
+    .replace(/ɔɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɔː")
+    .replace(/ɛɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɛə")
+    .replace(/ɪɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ɪə")
+    .replace(/ʊɹ(?![aeiouæɑɒəɛɪʌʊɔ])/g, "ʊə");
 
   // 3. Drop any remaining /ɹ/ in coda position (before a consonant or
   //    word boundary). Onset /ɹ/ — followed by a vowel — is preserved.
@@ -83,17 +66,38 @@ function applyRPRules(ipa: string): string {
   // 4. Tidy stray /əː/ artifacts → /ɜː/.
   out = out.replace(/əː/g, "ɜː");
 
+  // 5. French -age borrowings. AmE keeps the stressed back-vowel + ʒ
+  //    pattern (garage /ɡɝˈɑʒ/, sabotage /ˈsæbəˌtɑʒ/, espionage
+  //    /ˈɛspiənɑdʒ/). RP lengthens that vowel to /ɑː/ and drops any
+  //    affricate /d/. The IPA-side filter — final vowel must be one
+  //    of [ɑ ɒ æ] — keeps native English -age untouched (marriage
+  //    /ɪdʒ/, package /ədʒ/). Spelling check `[a-z]{2,}age$` excludes
+  //    monosyllables like rage / cage / sage.
+  if (/[a-z]{2,}age$/.test(word)) {
+    out = out.replace(/[ɑɒæ](d?)ʒ$/, "ɑːʒ");
+  }
+
+  // 6. Yod retention after word-initial /s/. AmE drops historical /j/
+  //    in sue / suit / super; RP keeps it. The lookbehind via spelling
+  //    (`^su` followed by another letter) plus the IPA negative
+  //    lookahead `(?!ʃ)` — to skip 'sushi' and similar — gives a tight
+  //    rule without an exception list. AmE base must start with /s/
+  //    directly followed by /u/, otherwise nothing fires.
+  if (/^su[a-z]/i.test(word)) {
+    out = out.replace(/^(ˈ?)su(?!ʃ)/, "$1sjuː");
+  }
+
   return out;
 }
 
 /**
- * Convert American-English IPA to RP IPA for the given word. Handles
- * word-level overrides first, then rule-based transformation.
+ * Convert American-English IPA to RP IPA for the given word. Looks up
+ * lexical shibboleths first; falls back to rule-based transformation.
  */
 export function transformAmericanToRP(word: string, ipaUS: string): string {
   const lower = word.toLowerCase();
-  const override = RP_WORD_OVERRIDES[lower];
-  if (override) return override;
+  const lex = RP_LEXICAL[lower];
+  if (lex) return lex;
 
-  return applyRPRules(ipaUS);
+  return applyRPRules(lower, ipaUS);
 }

--- a/src/g2p.ts
+++ b/src/g2p.ts
@@ -62,16 +62,27 @@ export function primaryLang(tag: string): string {
 }
 
 /**
+ * Normalize a BCP 47 tag for comparison. The spec defines tag matching
+ * as case-insensitive, so we lowercase before any equality check.
+ */
+export function normalizeTag(tag: string): string {
+  return tag.toLowerCase();
+}
+
+/**
  * True when `processorTag` covers `requestTag` under BCP 47 fallback:
- * exact match, or processor's tag is a prefix of the request.
+ * exact match (case-insensitive), or processor's tag is a prefix of
+ * the request.
  *
- *   "en"     covers "en", "en-US", "en-GB"
- *   "en-GB"  covers "en-GB" only
+ *   "en"     covers "en", "en-US", "en-GB", "en-gb"
+ *   "en-GB"  covers "en-GB" / "en-gb" only
  *   "en-US"  does NOT cover "en-GB"
  */
 function tagCovers(processorTag: string, requestTag: string): boolean {
-  if (processorTag === requestTag) return true;
-  return requestTag.startsWith(processorTag + "-");
+  const p = normalizeTag(processorTag);
+  const r = normalizeTag(requestTag);
+  if (p === r) return true;
+  return r.startsWith(p + "-");
 }
 
 // === G2P Registry ===
@@ -82,17 +93,28 @@ export class G2PRegistry {
   private order: G2PProcessor[] = [];
 
   register(processor: G2PProcessor): void {
-    this.processors.set(processor.id, processor);
-    if (!this.order.includes(processor)) {
+    // Re-registering the same id should swap the implementation in
+    // place, not stack a stale clone behind the live one. We replace
+    // the existing entry at its current position so dispatch order
+    // is preserved across rolling upgrades.
+    const existing = this.processors.get(processor.id);
+    if (existing) {
+      const idx = this.order.indexOf(existing);
+      if (idx !== -1) this.order[idx] = processor;
+      else this.order.push(processor);
+    } else {
       this.order.push(processor);
     }
+    this.processors.set(processor.id, processor);
   }
 
   unregister(id: string): boolean {
     const proc = this.processors.get(id);
     if (!proc) return false;
     this.processors.delete(id);
-    this.order = this.order.filter((p) => p !== proc);
+    // Remove every order-array reference, in case earlier code paths
+    // ever left duplicates behind.
+    this.order = this.order.filter((p) => p.id !== id);
     return true;
   }
 

--- a/src/g2p.ts
+++ b/src/g2p.ts
@@ -123,15 +123,18 @@ export class G2PRegistry {
   }
 
   getProcessorsForLanguage(language: string): G2PProcessor[] {
+    // Compare on normalized tags so `en-GB` and `en-gb` match alike.
+    const requestNorm = normalizeTag(language);
     const exact: G2PProcessor[] = [];
     const parent: G2PProcessor[] = [];
     for (const p of this.order) {
-      // Scan all tags; an exact match anywhere bumps the processor into
-      // the exact bucket. Otherwise classify on the first parent-cover.
+      // Scan all tags; an exact (case-insensitive) match anywhere
+      // bumps the processor into the exact bucket. Otherwise classify
+      // on the first parent-cover.
       let isExact = false;
       let isParent = false;
       for (const tag of p.supportedLanguages) {
-        if (tag === language) {
+        if (normalizeTag(tag) === requestNorm) {
           isExact = true;
           break;
         }

--- a/src/g2p.ts
+++ b/src/g2p.ts
@@ -1,8 +1,14 @@
 /**
  * Abstract G2P (Grapheme-to-Phoneme) Processor Interface
- * 
+ *
  * This module provides an abstraction layer for different G2P engines,
  * allowing dynamic registration and usage of language-specific processors.
+ *
+ * The exported `g2pRegistry` and free functions wrap a default global
+ * registry to preserve the simple `phonemize("hello")` API. To create
+ * isolated registrations (so multiple language sets can coexist without
+ * stepping on each other) use `new G2PRegistry()` directly or the
+ * higher-level `createPhonemizer()` factory in `core.ts`.
  */
 
 // === Type Definitions ===
@@ -12,21 +18,23 @@ export interface G2PProcessor {
    * Unique identifier for this G2P processor
    */
   readonly id: string;
-  
+
   /**
    * Human-readable name for this G2P processor
    */
   readonly name: string;
-  
+
   /**
-   * Languages this processor can handle
-   * Array of ISO 639-1 language codes (e.g., ['en', 'zh', 'ja'])
+   * Languages this processor can handle. Use BCP 47-style tags; the
+   * registry treats `en` as a parent of `en-US`/`en-GB` etc., so a
+   * processor that lists `["en"]` will be selected for `en-GB` requests
+   * unless a more specific processor is also registered.
    */
   readonly supportedLanguages: string[];
-  
+
   /**
    * Predict phonemes for a given word
-   * 
+   *
    * @param word - Word to convert to phonemes
    * @param language - Language code (optional, for disambiguation)
    * @param pos - Part of speech (optional, for homograph disambiguation)
@@ -36,215 +44,198 @@ export interface G2PProcessor {
 
   /**
    * Add a custom pronunciation for a word
-   * 
+   *
    * @param word - Word to add pronunciation for
    * @param pronunciation - IPA pronunciation string
    */
   addPronunciation(word: string, pronunciation: string): void;
 }
 
+// === Language tag helpers ===
+
+/**
+ * Return the primary language subtag — `en-GB` → `en`, `zh-Hant-TW` → `zh`.
+ */
+export function primaryLang(tag: string): string {
+  const idx = tag.indexOf("-");
+  return idx === -1 ? tag : tag.slice(0, idx);
+}
+
+/**
+ * True when `processorTag` covers `requestTag` under BCP 47 fallback:
+ * exact match, or processor's tag is a prefix of the request.
+ *
+ *   "en"     covers "en", "en-US", "en-GB"
+ *   "en-GB"  covers "en-GB" only
+ *   "en-US"  does NOT cover "en-GB"
+ */
+function tagCovers(processorTag: string, requestTag: string): boolean {
+  if (processorTag === requestTag) return true;
+  return requestTag.startsWith(processorTag + "-");
+}
+
 // === G2P Registry ===
 
-class G2PRegistry {
+export class G2PRegistry {
   private processors: Map<string, G2PProcessor> = new Map();
-  private languageMap: Map<string, G2PProcessor[]> = new Map();
-  
-  /**
-   * Register a G2P processor
-   * 
-   * @param processor - G2P processor to register
-   */
+  /** Insertion order for stable "first registered wins" semantics. */
+  private order: G2PProcessor[] = [];
+
   register(processor: G2PProcessor): void {
-    // Register by ID
     this.processors.set(processor.id, processor);
-    
-    // Register by supported languages
-    for (const lang of processor.supportedLanguages) {
-      if (!this.languageMap.has(lang)) {
-        this.languageMap.set(lang, []);
-      }
-      this.languageMap.get(lang)!.push(processor);
+    if (!this.order.includes(processor)) {
+      this.order.push(processor);
     }
   }
-  
-  /**
-   * Get processor by ID
-   * 
-   * @param id - Processor ID
-   * @returns G2P processor or undefined
-   */
+
+  unregister(id: string): boolean {
+    const proc = this.processors.get(id);
+    if (!proc) return false;
+    this.processors.delete(id);
+    this.order = this.order.filter((p) => p !== proc);
+    return true;
+  }
+
   getProcessor(id: string): G2PProcessor | undefined {
     return this.processors.get(id);
   }
-  
-  /**
-   * Get processors that support a specific language
-   * 
-   * @param language - Language code
-   * @returns Array of processors that support the language
-   */
+
   getProcessorsForLanguage(language: string): G2PProcessor[] {
-    return this.languageMap.get(language) || [];
-  }
-  
-  /**
-   * Get all registered processors
-   * 
-   * @returns Array of all registered processors
-   */
-  getAllProcessors(): G2PProcessor[] {
-    return Array.from(this.processors.values());
-  }
-  
-  /**
-   * Find the best processor for a given word and language
-   * 
-   * @param word - Word to process
-   * @param language - Language code (optional)
-   * @returns Best matching processor or null
-   */
-  findBestProcessor(word: string, language?: string): G2PProcessor | null {
-    // If language is specified, try processors for that language first
-    if (language) {
-      const langProcessors = this.getProcessorsForLanguage(language);
-      if (langProcessors.length > 0) {
-        return langProcessors[0]; // Return first processor for the language
+    const exact: G2PProcessor[] = [];
+    const parent: G2PProcessor[] = [];
+    for (const p of this.order) {
+      // Scan all tags; an exact match anywhere bumps the processor into
+      // the exact bucket. Otherwise classify on the first parent-cover.
+      let isExact = false;
+      let isParent = false;
+      for (const tag of p.supportedLanguages) {
+        if (tag === language) {
+          isExact = true;
+          break;
+        }
+        if (tagCovers(tag, language)) isParent = true;
       }
+      if (isExact) exact.push(p);
+      else if (isParent) parent.push(p);
     }
-    
-    // If no language specified or no processor found, try all processors
-    const allProcessors = Array.from(this.processors.values());
-    if (allProcessors.length > 0) {
-      return allProcessors[0]; // Return first available processor
-    }
-    
-    return null;
+    // Prefer exact dialect match (en-GB) over parent (en) match.
+    return exact.concat(parent);
+  }
+
+  getAllProcessors(): G2PProcessor[] {
+    return this.order.slice();
   }
 
   /**
-   * Clear all registered processors
+   * Find the best processor for a given word and language. When a
+   * language is provided, dialect-exact processors are tried first,
+   * then parent-tag processors. With no language we fall back to the
+   * first registered processor.
    */
+  findBestProcessor(_word: string, language?: string): G2PProcessor | null {
+    if (language) {
+      const matches = this.getProcessorsForLanguage(language);
+      if (matches.length > 0) return matches[0];
+    }
+    return this.order[0] ?? null;
+  }
+
+  predictPhonemes(
+    word: string,
+    language?: string,
+    pos?: string,
+  ): string | null {
+    let lang = language;
+    if (!lang) {
+      const detected = detectLanguage(word);
+      if (detected) lang = detected;
+    }
+    const processor = this.findBestProcessor(word, lang);
+    if (!processor) return null;
+    const result = processor.predict(word, lang, pos);
+    return result && result.trim() ? result : null;
+  }
+
   clear(): void {
     this.processors.clear();
-    this.languageMap.clear();
+    this.order = [];
   }
 
-  /**
-   * Get all supported languages
-   * 
-   * @returns Array of supported language codes
-   */
   getSupportedLanguages(): string[] {
-    return Array.from(this.languageMap.keys());
+    const set = new Set<string>();
+    for (const p of this.order) {
+      for (const lang of p.supportedLanguages) set.add(lang);
+    }
+    return Array.from(set);
   }
 }
 
-// === Global Registry Instance ===
+// === Default global registry (preserves simple `phonemize` API) ===
 
 export const g2pRegistry = new G2PRegistry();
 
 // === Language Detection ===
 
-const CHINESE_CHARS = /[\u4e00-\u9fa5]/;
-const JAPANESE_CHARS = /[\u3040-\u30ff]/;
-const KOREAN_CHARS = /[\uac00-\ud7af]/;
-const RUSSIAN_CHARS = /[\u0400-\u04FF]/;
+const CHINESE_CHARS = /[一-龥]/;
+const JAPANESE_CHARS = /[぀-ヿ]/;
+const KOREAN_CHARS = /[가-힯]/;
+const RUSSIAN_CHARS = /[Ѐ-ӿ]/;
 const GERMAN_CHARS = /[äöüÄÖÜß]/;
-const ARABIC_CHARS = /[\u0600-\u06FF]/;
-const THAI_CHARS = /[\u0e00-\u0e7f]/;
+const ARABIC_CHARS = /[؀-ۿ]/;
+const THAI_CHARS = /[฀-๿]/;
 
 /**
  * Detect the language of the given text based on Unicode character ranges
- * 
+ *
  * @param text - Text to detect language for
  * @returns Language code or null if not detected
  */
 export function detectLanguage(text: string): string | null {
-  if (CHINESE_CHARS.test(text)) return 'zh';
-  if (JAPANESE_CHARS.test(text)) return 'ja';
-  if (KOREAN_CHARS.test(text)) return 'ko';
-  if (RUSSIAN_CHARS.test(text)) return 'ru';
-  if (GERMAN_CHARS.test(text)) return 'de';
-  if (ARABIC_CHARS.test(text)) return 'ar';
-  if (THAI_CHARS.test(text)) return 'th';
+  if (CHINESE_CHARS.test(text)) return "zh";
+  if (JAPANESE_CHARS.test(text)) return "ja";
+  if (KOREAN_CHARS.test(text)) return "ko";
+  if (RUSSIAN_CHARS.test(text)) return "ru";
+  if (GERMAN_CHARS.test(text)) return "de";
+  if (ARABIC_CHARS.test(text)) return "ar";
+  if (THAI_CHARS.test(text)) return "th";
 
   return null;
 }
 
-// === Public API ===
+// === Public API (default global registry wrappers) ===
 
 /**
- * Use a specific G2P processor by instance
- * 
- * @param processor - G2P processor instance to use
+ * Register a G2P processor on the default global registry.
+ *
+ * For multi-instance setups, prefer `createPhonemizer()` from `./core`.
  */
 export function useG2P(processor: G2PProcessor): void {
   g2pRegistry.register(processor);
 }
 
-/**
- * Get the best G2P processor for a word
- * 
- * @param word - Word to process
- * @param language - Language code (optional)
- * @returns G2P processor or null
- */
-export function getG2PProcessor(word: string, language?: string): G2PProcessor | null {
+export function getG2PProcessor(
+  word: string,
+  language?: string,
+): G2PProcessor | null {
   return g2pRegistry.findBestProcessor(word, language);
 }
 
-/**
- * Predict phonemes using the best available processor
- * 
- * @param word - Word to convert
- * @param language - Language code (optional)
- * @param pos - Part of speech (optional)
- * @returns Phoneme string or null if no processor can handle it
- */
-export function predictPhonemes(word: string, language?: string, pos?: string): string | null {
-  // If no language specified, try to detect it
-  if (!language) {
-    const detectedLang = detectLanguage(word);
-    if (detectedLang) {
-      language = detectedLang;
-    }
-  }
-  
-  const processor = g2pRegistry.findBestProcessor(word, language);
-  if (processor) {
-    const result = processor.predict(word, language, pos);
-    // Return null if processor returns empty string or null
-    return result && result.trim() ? result : null;
-  }
-  return null;
+export function predictPhonemes(
+  word: string,
+  language?: string,
+  pos?: string,
+): string | null {
+  return g2pRegistry.predictPhonemes(word, language, pos);
 }
 
-/**
- * Get all registered processor IDs
- * 
- * @returns Array of processor IDs
- */
 export function getRegisteredProcessorIds(): string[] {
-  return g2pRegistry.getAllProcessors().map(p => p.id);
+  return g2pRegistry.getAllProcessors().map((p) => p.id);
 }
 
-/**
- * Get processors that support a specific language
- * 
- * @param language - Language code
- * @returns Array of processors that support the language
- */
 export function getProcessorsForLanguage(language: string): G2PProcessor[] {
   return g2pRegistry.getProcessorsForLanguage(language);
 }
 
-// === Utility Functions ===
-
-/**
- * Get all supported languages
- * 
- * @returns Array of supported language codes
- */
 export function getSupportedLanguages(): string[] {
   return g2pRegistry.getSupportedLanguages();
 }

--- a/src/g2p.ts
+++ b/src/g2p.ts
@@ -126,25 +126,36 @@ export class G2PRegistry {
     // Compare on normalized tags so `en-GB` and `en-gb` match alike.
     const requestNorm = normalizeTag(language);
     const exact: G2PProcessor[] = [];
-    const parent: G2PProcessor[] = [];
+    // Among parent matches, the most-specific prefix should win — so
+    // for a request `en-US-x-foo` a processor declaring `en-US` must
+    // outrank one declaring bare `en`. We track each parent's best
+    // matching prefix length and stable-sort by it descending.
+    const parentEntries: { proc: G2PProcessor; matchLen: number; order: number }[] = [];
+    let idx = 0;
     for (const p of this.order) {
-      // Scan all tags; an exact (case-insensitive) match anywhere
-      // bumps the processor into the exact bucket. Otherwise classify
-      // on the first parent-cover.
       let isExact = false;
-      let isParent = false;
+      let bestParentLen = 0;
       for (const tag of p.supportedLanguages) {
-        if (normalizeTag(tag) === requestNorm) {
+        const tagNorm = normalizeTag(tag);
+        if (tagNorm === requestNorm) {
           isExact = true;
           break;
         }
-        if (tagCovers(tag, language)) isParent = true;
+        if (tagCovers(tag, language) && tagNorm.length > bestParentLen) {
+          bestParentLen = tagNorm.length;
+        }
       }
       if (isExact) exact.push(p);
-      else if (isParent) parent.push(p);
+      else if (bestParentLen > 0) {
+        parentEntries.push({ proc: p, matchLen: bestParentLen, order: idx });
+      }
+      idx++;
     }
+    parentEntries.sort((a, b) =>
+      b.matchLen - a.matchLen || a.order - b.order,
+    );
     // Prefer exact dialect match (en-GB) over parent (en) match.
-    return exact.concat(parent);
+    return exact.concat(parentEntries.map((e) => e.proc));
   }
 
   getAllProcessors(): G2PProcessor[] {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -377,11 +377,15 @@ export class Tokenizer {
       // Resolve language for this token. Script-detected languages (CJK,
       // Cyrillic, etc.) win over the user-supplied preferred language —
       // e.g. `phonemize("hello 中文", "en-GB")` still routes 中文 to the
-      // Chinese processor. For tokens with no script-derived language
-      // (Latin script falls through to "en" by default), use the
-      // preferred language so en-GB / en-US can be selected explicitly.
+      // Chinese processor. The languageMap is keyed by whitespace-split
+      // chunks, but the actual tokenizer can split a chunk further
+      // (e.g. "hello中文" without a space → tokens "hello" + "中文"),
+      // so we re-run script detection on the per-token string before
+      // falling back to the preferred language.
       const detectedLanguage =
-        languageMap[cleanToken.toLowerCase()] ?? this.options.language;
+        languageMap[cleanToken.toLowerCase()]
+        ?? detectLanguage(cleanToken)
+        ?? this.options.language;
 
       // Handle Zhuyin format specially
       if (this.options.format === "zhuyin" && detectedLanguage === "zh") {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -6,10 +6,13 @@
 import anyAscii from "./anyascii";
 import { expandText } from "./expand";
 import { simplePOSTagger } from "./pos-tagger";
-import { ARPABET_TO_IPA, IPA_STRESS_MAP, PUNCTUATION } from "./consts";
-import { detectLanguage, getG2PProcessor, predictPhonemes } from "./g2p";
+import { PUNCTUATION } from "./consts";
+import {
+  detectLanguage,
+  g2pRegistry as defaultRegistry,
+  G2PRegistry,
+} from "./g2p";
 import { ipaToArpabet, convertChineseTonesToArrows } from "./utils";
-import type { G2PProcessor } from "./g2p";
 import type ChineseG2P from "./zh-g2p";
 
 // Tokenization regex patterns
@@ -23,7 +26,7 @@ export interface TokenizerOptions {
   stripStress?: boolean;
   /**
    * Output format (IPA, ARPABET, or Zhuyin)
-   * 
+   *
    * Note: Non-chinese in zhuyin format will be converted to IPA
    **/
   format?: "ipa" | "arpabet" | "zhuyin";
@@ -33,6 +36,23 @@ export interface TokenizerOptions {
   anyAscii?: boolean;
   /** Chinese tone format: 'unicode' (˧˩˧) or 'arrow' (↓↗↘→). Only applies when format is 'ipa' */
   toneFormat?: "unicode" | "arrow";
+  /**
+   * Preferred language tag (BCP 47, e.g. "en", "en-GB", "zh").
+   *
+   * When set, the tokenizer skips Unicode-based auto-detection for words
+   * that don't clearly belong to a different script and routes them to
+   * a G2P processor matching this tag. Words written in a script that
+   * unambiguously identifies another language (e.g. Han for Chinese)
+   * still go through their script-detected processor.
+   */
+  language?: string;
+  /**
+   * G2P registry to use for phoneme prediction. Defaults to the global
+   * registry populated by the package's `useG2P()` calls. Pass a custom
+   * registry (or use `createPhonemizer()`) for isolated multi-instance
+   * setups.
+   */
+  registry?: G2PRegistry;
 }
 
 /**
@@ -69,17 +89,21 @@ interface PreprocessResult {
  * Main tokenizer class for phoneme processing
  */
 export class Tokenizer {
-  protected readonly options: Required<TokenizerOptions>;
+  protected readonly options: Required<Omit<TokenizerOptions, "language" | "registry">> & {
+    language: string | undefined;
+  };
+  protected readonly registry: G2PRegistry;
 
   constructor(options: TokenizerOptions = {}) {
     this.options = {
-      stripStress: false,
-      format: "ipa",
-      separator: " ",
-      anyAscii: false,
-      toneFormat: "unicode",
-      ...options,
+      stripStress: options.stripStress ?? false,
+      format: options.format ?? "ipa",
+      separator: options.separator ?? " ",
+      anyAscii: options.anyAscii ?? false,
+      toneFormat: options.toneFormat ?? "unicode",
+      language: options.language,
     };
+    this.registry = options.registry ?? defaultRegistry;
   }
 
   /**
@@ -281,7 +305,7 @@ export class Tokenizer {
   }
 
   private _predict(token: string, language: string, pos: string): string {
-    const predicted = predictPhonemes(token, language, pos);
+    const predicted = this.registry.predictPhonemes(token, language, pos);
     return this._postProcess(predicted || token);
   }
 
@@ -350,13 +374,22 @@ export class Tokenizer {
 
       let phoneme: string;
 
-      // Check language map for multilingual words
-      const detectedLanguage = languageMap[cleanToken.toLowerCase()];
-      
+      // Resolve language for this token. Script-detected languages (CJK,
+      // Cyrillic, etc.) win over the user-supplied preferred language —
+      // e.g. `phonemize("hello 中文", "en-GB")` still routes 中文 to the
+      // Chinese processor. For tokens with no script-derived language
+      // (Latin script falls through to "en" by default), use the
+      // preferred language so en-GB / en-US can be selected explicitly.
+      const detectedLanguage =
+        languageMap[cleanToken.toLowerCase()] ?? this.options.language;
+
       // Handle Zhuyin format specially
       if (this.options.format === "zhuyin" && detectedLanguage === "zh") {
         // Convert Chinese to Zhuyin
-        const g2p = getG2PProcessor(cleanToken, detectedLanguage) as ChineseG2P | null;
+        const g2p = this.registry.findBestProcessor(
+          cleanToken,
+          detectedLanguage,
+        ) as ChineseG2P | null;
         phoneme = g2p?.textToZhuyin?.(cleanToken) ?? this._predict(cleanToken, detectedLanguage, pos);
       } else {
         // Regular IPA/ARPABET processing

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,14 +2,13 @@
  * Utility functions for phoneme format conversion
  */
 
-import { 
-  IPA_TO_ARPABET, 
-  IPA_TO_STRESS, 
-  ARPABET_TO_IPA, 
-  IPA_STRESS_MAP, 
+import {
+  IPA_TO_ARPABET,
+  IPA_TO_STRESS,
+  ARPABET_TO_IPA,
   CHINESE_TONE_TO_ARROW,
   PINYIN_INITIALS_TO_ZHUYIN,
-  PINYIN_FINALS_TO_ZHUYIN
+  PINYIN_FINALS_TO_ZHUYIN,
 } from "./consts";
 
 /**
@@ -27,7 +26,15 @@ export function ipaToArpabet(ipa: string): string {
   
   while (i < ipa.length) {
     const char = ipa[i];
-    
+
+    // ARPABET has no length distinction. Strip the IPA length mark
+    // ('ː', U+02D0) silently — it's emitted by the en-GB transform
+    // but carries no information ARPABET can represent.
+    if (char === "ː") {
+      i++;
+      continue;
+    }
+
     // Handle stress markers
     if (IPA_TO_STRESS[char]) {
       const stress = IPA_TO_STRESS[char];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "incremental": false,
     "declaration": true,
     "resolveJsonModule": true,
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
## Summary

Three connected changes:

1. **Multi-instance support** — `G2PRegistry` is now exportable and instantiable. `createPhonemizer({ g2ps: [...] })` / `new Phonemizer()` give callers an isolated registry while the simple `phonemize('hello')` API keeps working off the default global registry. Closes #4.
2. **Preferred language argument** — `TokenizerOptions` gains a `language` tag (BCP 47); `phonemize(text, 'en-GB')` is sugar for `{ language: 'en-GB' }`. Script-detected languages (CJK, Cyrillic) still win, so mixed-language strings keep behaving sensibly.
3. **English dialects without a second dictionary** — `EnglishG2P` accepts `dialect: 'en-US' | 'en-GB'` (default `en-US`). RP is produced by rule-based post-processing on the AmE base in a new `src/en-gb.ts` — no extra dict shipped, no package-size hit.

RP coverage: non-rhoticity (`car` → `ˈkɑː`), NURSE split by stress (`bird` → `ˈbɜːd`, `doctor` → `ˈdɑktə`), SQUARE/NEAR/CURE diphthongs (`hair` → `ˈhɛə`, `near` → `ˈnɪə`), FIRE/POWER (`fire` → `ˈfaɪə`), and word-level overrides for high-impact mismatches (`garage`, `sue`, `super`, `information`, `schedule`, `tomato`, …).

`addPronunciation()` now writes to a per-instance custom-dict overlay so calls on one `Phonemizer` don't leak into other instances created in the same process.

## Test plan

- [x] 204 tests pass (171 baseline + 33 new across `__tests__/en-gb.test.ts` and `__tests__/multi-instance.test.ts`)
- [x] `yarn build` clean
- [x] `node scripts/performance-benchmark.js` — 159k words/sec, no regression
- [x] Backward compat: `phonemize('Hello world!')` still produces `həˈɫoʊ ˈwɝɫd!` exactly as before
- [x] BCP 47 fallback: registering `EnglishG2P` (declares `['en', 'en-US', 'en-GB']`) plus a hypothetical `gb-only` (declares `['en-GB']`) — exact-match preferred, then insertion order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dispatch/tokenization and G2P registry selection logic, which can subtly change phonemization results across languages and formats. New dialect post-processing also changes English output when `language`/dialect is specified.
> 
> **Overview**
> Introduces a **multi-instance API** via `createPhonemizer()`/`Phonemizer`, letting callers use isolated `G2PRegistry` instances (with `useG2P`, `unregister`, and instance-scoped `addPronunciation`) while keeping the existing global `phonemize()` behavior.
> 
> Adds a **preferred language tag** (`TokenizerOptions.language`) and **string shorthand** for `phonemize`/`toIPA`/`toARPABET`/`toZhuyin` to bias processor selection, while still letting script detection override for unambiguous non-Latin tokens.
> 
> Extends `EnglishG2P` to support **dialects** (`en-US` default, `en-GB`) by applying a new rule-based RP post-processor (`transformAmericanToRP` in `src/en-gb.ts`), and updates matching/selection in `G2PRegistry` for BCP47 parent/dialect fallback. Adds comprehensive tests for RP transforms and multi-instance isolation, and updates the README to document the new APIs and dialect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c96dedf3201780039666d508f72b4789b66f5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->